### PR TITLE
api-schema: Prevent "no error" error messages

### DIFF
--- a/response.go
+++ b/response.go
@@ -55,7 +55,7 @@ func ParseResponse(resBody *io.ReadCloser) (*Response, error) {
 		if err := json.Unmarshal(byteSlice, &target); err != nil {
 			// In case we receive a response we did not expect and cannot read, we just
 			// return an error containing the content of the response.
-			return nil, errgo.New(string(byteSlice))
+			return nil, newUnexpectedContentError(string(byteSlice))
 		}
 	}
 
@@ -80,7 +80,7 @@ func (resp *Response) UnmarshalData(v interface{}) error {
 	if err := json.Unmarshal(resp.Data, v); err != nil {
 		// In case we receive a data field we did not expect, we just
 		// return an error containing the content of the response.
-		return errgo.New(string(resp.Data))
+		return newUnexpectedContentError(string(resp.Data))
 	}
 
 	return nil

--- a/util.go
+++ b/util.go
@@ -70,7 +70,7 @@ func ParseData(resBody *io.ReadCloser, v interface{}) error {
 	if err := json.Unmarshal(byteSlice, &target); err != nil {
 		// In case we receive a response we did not expect and cannot read, we just
 		// return an error containing the content of the response.
-		return errgo.New(string(byteSlice))
+		return newUnexpectedContentError(string(byteSlice))
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func isStatus(statusCode int, reason, responseBody string) (bool, error) {
 	if err := json.Unmarshal([]byte(responseBody), &responsePayload); err != nil {
 		// In case we receive a response we did not expect and cannot read, we just
 		// return an error containing the content of the response.
-		return false, errgo.Newf(responseBody)
+		return false, newUnexpectedContentError(responseBody)
 	}
 
 	if responsePayload.StatusCode == statusCode {
@@ -99,6 +99,16 @@ func isStatus(statusCode int, reason, responseBody string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// newUnexpectedContentError creates an error containing the given content as messages, unless that is empty.
+// In that case a human readable message is returned.
+func newUnexpectedContentError(content string) error {
+	if content == "" {
+		return errgo.New("Unexpected empty response")
+	} else {
+		return errgo.New(content)
+	}
 }
 
 func newReason(text, reason string) string {


### PR DESCRIPTION
Needed for giantswarm/cli#192

This change prevents errors that have a Message equal to "" since these kind of messages result in a "<no error>" string.