### PR TITLE
api-schema: Fixed text of StatusUserErrorWithReason and StatusServerErrorWithReason

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -65,11 +65,11 @@ func StatusWrongInputWithReason(reason string) *Response {
 }
 
 func StatusUserErrorWithReason(reason string) *Response {
-	return NewEmptyResponse(STATUS_CODE_USER_ERROR, newReason("user error", reason))
+	return NewEmptyResponse(STATUS_CODE_USER_ERROR, reason)
 }
 
 func StatusServerErrorWithReason(reason string) *Response {
-	return NewEmptyResponse(STATUS_CODE_SERVER_ERROR, newReason("server error", reason))
+	return NewEmptyResponse(STATUS_CODE_SERVER_ERROR, reason)
 }
 
 func StatusInvalidVersion() *Response {


### PR DESCRIPTION
The reason text should be passed as plain reason text, not with a fixed "user_error" in front of it.