### PR TITLE
api-schema: Server error with reason

### DIFF
--- a/error.go
+++ b/error.go
@@ -37,7 +37,7 @@ func checkResponseErrorStatusCode(err error, statusCode int, reason string) bool
 	if reason != "" {
 		// Check reason part of the status text.
 		// See also util.go#newReason
-		if !strings.HasSuffix(respErr.statusText, ": "+reason) {
+		if (respErr.statusText != reason) && !strings.HasSuffix(respErr.statusText, ": "+reason) {
 			return false
 		}
 	}

--- a/error.go
+++ b/error.go
@@ -81,6 +81,10 @@ func IsServerError(err error) bool {
 	return checkResponseErrorStatusCode(err, STATUS_CODE_SERVER_ERROR, "")
 }
 
+func IsServerErrorWithReason(err error, reason string) bool {
+	return checkResponseErrorStatusCode(err, STATUS_CODE_SERVER_ERROR, reason)
+}
+
 func IsInvalidVersionError(err error) bool {
 	return checkResponseErrorStatusCode(err, STATUS_CODE_INVALID_VERSION_ERROR, "")
 }


### PR DESCRIPTION
This PR changes:

- Adds an IsServerErrorWithReason function
- Allows reason strings to take up the entire statusText field on ResponsePayload structure.

Needed for giantswarm/cli#218