### PR TITLE
Prepare release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.1] 2020-04-14
+
+### Added
+
+- First recorded release; added changelog.
+
+
+[Unreleased]: https://github.com/giantswarm/api-schema/compare/v0.7.1..HEAD
+[0.7.1]: https://github.com/giantswarm/api-schema/releases/tag/v0.7.1


### PR DESCRIPTION
`go mod` requires repositories to be versioned according to semantic versioning scheme.

Towards giantswarm/giantswarm#9192